### PR TITLE
chore: bump elixir

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1.15.4
         with:
-          elixir-version: '1.15.2' # [Required] Define the Elixir version
-          otp-version: '26.0'      # [Required] Define the Erlang/OTP version
+          elixir-version: '1.15.7' # [Required] Define the Elixir version
+          otp-version: '26.1.1'      # [Required] Define the Erlang/OTP version
 
       - name: Restore dependencies cache
         uses: actions/cache@v3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.6-otp-26
+elixir 1.15.7-otp-26
 erlang 26.1.1

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule GoBillManager.MixProject do
     [
       app: :go_bill_manager,
       version: "0.1.0",
-      elixir: "~> 1.12",
+      elixir: "~> 1.15.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
Atualizando a versão do elixir para a mais recente hoje, dia 04/12/2023

https://github.com/elixir-lang/elixir/releases/tag/v1.15.7