### PR TITLE
feat: create web error responses handler

### DIFF
--- a/lib/go_bill_manager_web.ex
+++ b/lib/go_bill_manager_web.ex
@@ -25,6 +25,7 @@ defmodule GoBillManagerWeb do
       import Plug.Conn
       import GoBillManagerWeb.Gettext
       alias GoBillManagerWeb.Router.Helpers, as: Routes
+      alias GoBillManagerWeb.ErrorResponses
     end
   end
 

--- a/lib/go_bill_manager_web/controllers/bill_controller.ex
+++ b/lib/go_bill_manager_web/controllers/bill_controller.ex
@@ -13,10 +13,10 @@ defmodule GoBillManagerWeb.BillController do
       render(conn, "create.json", %{bill: bill})
     else
       {:error, %Ecto.Changeset{}} ->
-        parse_response_to_json(conn, 400, %{type: "error:invalid_params"})
+        ErrorResponses.bad_request(conn, "invalid_params")
 
       {:error, :employee_not_found} ->
-        parse_response_to_json(conn, 404, %{type: "error:employee_not_found_or_exists"})
+        ErrorResponses.not_found(conn, "employee_not_found")
 
       {:error, reason} ->
         {:error, reason}
@@ -33,17 +33,11 @@ defmodule GoBillManagerWeb.BillController do
       render(conn, "simplified_bill.json", %{bill: bill})
     else
       {:error, :invalid_uuid} ->
-        parse_response_to_json(conn, 400, %{type: "error:invalid_bill_id"})
+        ErrorResponses.bad_request(conn, "invalid_bill_id")
 
       {:error, :bill_not_found} ->
-        parse_response_to_json(conn, 404, %{type: "error:bill_not_found"})
+        ErrorResponses.not_found(conn, "bill_not_found")
     end
-  end
-
-  defp parse_response_to_json(conn, status, value) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(status, Jason.encode!(value))
   end
 
   defp validate_uuid(bill_id) do

--- a/lib/go_bill_manager_web/controllers/customer_table_controller.ex
+++ b/lib/go_bill_manager_web/controllers/customer_table_controller.ex
@@ -13,7 +13,7 @@ defmodule GoBillManagerWeb.CustomerTableController do
       render(conn, "create.json", %{customer_table: customer_table})
     else
       {:error, %Ecto.Changeset{}} ->
-        parse_response_to_json(conn, 400, %{type: "error:invalid_params"})
+        ErrorResponses.bad_request(conn, "invalid_params")
 
       {:error, reason} ->
         {:error, reason}
@@ -34,17 +34,11 @@ defmodule GoBillManagerWeb.CustomerTableController do
       render(conn, "simplified_customer_table.json", %{customer_table: customer_table})
     else
       {:error, :invalid_uuid} ->
-        parse_response_to_json(conn, 400, %{type: "error:invalid_customer_table_id"})
+        ErrorResponses.bad_request(conn, "invalid_customer_table_id")
 
       {:error, :customer_table_not_found} ->
-        parse_response_to_json(conn, 404, %{type: "error:customer_table_not_found"})
+        ErrorResponses.not_found(conn, "customer_table_not_found")
     end
-  end
-
-  defp parse_response_to_json(conn, status, value) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(status, Jason.encode!(value))
   end
 
   defp validate_uuid(customer_table_id) do

--- a/lib/go_bill_manager_web/controllers/employee_controller.ex
+++ b/lib/go_bill_manager_web/controllers/employee_controller.ex
@@ -12,9 +12,8 @@ defmodule GoBillManagerWeb.EmployeeController do
     with {:ok, employee} <- EmployeeCreate.run(params) do
       render(conn, "create.json", %{employee: employee})
     else
-      # TODO - improve nos retornos de erro: required_params
       {:error, %Ecto.Changeset{}} ->
-        parse_response_to_json(conn, 400, %{type: "error:invalid_params"})
+        ErrorResponses.bad_request(conn, "invalid_params")
 
       {:error, reason} ->
         {:error, reason}
@@ -32,17 +31,11 @@ defmodule GoBillManagerWeb.EmployeeController do
       render(conn, "simplified_employee.json", %{employee: employee})
     else
       {:error, :invalid_uuid} ->
-        parse_response_to_json(conn, 400, %{type: "error:invalid_employee_id"})
+        ErrorResponses.bad_request(conn, "invalid_employee_id")
 
       {:error, :employee_not_found} ->
-        parse_response_to_json(conn, 404, %{type: "error:employee_not_found"})
+        ErrorResponses.not_found(conn, "employee_not_found")
     end
-  end
-
-  defp parse_response_to_json(conn, status, value) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(status, Jason.encode!(value))
   end
 
   defp validate_uuid(employee_id) do

--- a/lib/go_bill_manager_web/error_responses.ex
+++ b/lib/go_bill_manager_web/error_responses.ex
@@ -1,0 +1,45 @@
+defmodule GoBillManagerWeb.ErrorResponses do
+  @moduledoc """
+  Handle with http error responses messages
+  """
+  import Plug.Conn
+  alias Plug.Conn
+
+  @typedoc """
+  Valid possibles to parse as JSON
+  """
+  @type json :: String.t() | number() | list(json()) | %{required(String.t() | atom()) => json}
+
+  @doc """
+  HTTP status: 400
+
+  The request is wrong
+  """
+  @spec bad_request(Conn.t(), error :: String.t() | atom() | map()) :: Conn.t()
+  def bad_request(conn, error \\ "bad_request")
+
+  def bad_request(conn, reason) when is_map(reason),
+    do: parse_response_to_json(conn, 400, reason)
+
+  def bad_request(conn, error) when is_binary(error) or is_atom(error) do
+    parse_response_to_json(conn, 400, %{type: type(error)})
+  end
+
+  @spec not_found(Conn.t(), reason :: String.t() | atom()) :: Conn.t()
+  def not_found(conn, reason) when is_binary(reason) or is_atom(reason) do
+    parse_response_to_json(conn, 404, %{type: type(reason)})
+  end
+
+  @spec parse_response_to_json(Conn.t(), integer(), json()) :: Conn.t()
+  def parse_response_to_json(conn, status, value) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Jason.encode!(value))
+  end
+
+  @doc """
+  Default type error responses
+  """
+  @spec type(type :: String.t() | atom()) :: String.t()
+  def type(type), do: "error:#{type}"
+end

--- a/test/go_bill_manager_web/controllers/bill_controller_test.exs
+++ b/test/go_bill_manager_web/controllers/bill_controller_test.exs
@@ -44,7 +44,7 @@ defmodule GoBillManagerWeb.BillControllerTest do
 
       response = json_response(conn, 404)
 
-      assert response == %{"type" => "error:employee_not_found_or_exists"}
+      assert response == %{"type" => "error:employee_not_found"}
       assert conn.status == 404
 
       assert log =~


### PR DESCRIPTION
Criei um módulo para centralizar o tratamento de mensagens de erro http, como bad request, not found. 

Eram blocos de códigos pequenos que estavam se repetindo pelas controllers, vou poder usar em qualquer lugar o mesmo comportamento, agora padronizado.